### PR TITLE
Declare build-system dependencies and correctly exclude tests from packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[build-system]
+requires = ["setuptools", "toml"]
+
 [tool]
 [tool.poetry]
 name = "sysrsync"

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/gchamon/sysrsync",
-    packages=setuptools.find_packages(exclude=['tests']),
+    packages=setuptools.find_packages(exclude=['test']),
     platforms='any',
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This PR allows the package to be built without issues by, e.g.:

```sh
python3 -m build
```

or by https://src.fedoraproject.org/rpms/pyproject-rpm-macros.

Details are in the individual commit messages.