### PR TITLE
In Python 3.11 and later, use tomllib instead of toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "toml"]
+requires = ["setuptools", "toml; python_version < '3.11'"]
 
 [tool]
 [tool.poetry]
@@ -12,7 +12,7 @@ homepage = "https://github.com/gchamon/sysrsync"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-toml = "^0.10.0"
+toml = { version = "^0.10.0", python = "<3.11" }
 
 [tool.poetry.dev-dependencies]
 autopep8 = "*"

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,17 @@
 """Setup script for sysrsync."""
 import setuptools
-import toml
 
-pyproject = toml.load("pyproject.toml")
+try:
+    # Python 3.11 and later
+    import tomllib
+except ImportError:
+    # Python 3.10 and earlier
+    import toml
+
+    pyproject = toml.load("pyproject.toml")
+else:
+    with open("pyproject.toml", "rb") as fh:
+        pyproject = tomllib.load(fh)
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
This removes the dependency on [`toml`](https://pypi.org/project/toml/) for Python versions that have [`tomllib`](https://docs.python.org/3/library/tomllib.html) in the standard library.

I tested this without using Poetry; I did not attempt to meddle with `Poetry.lock` or `requirements.txt`.