### PR TITLE
fix: add single quote around `rsh` arg

### DIFF
--- a/sysrsync/helpers/rsync.py
+++ b/sysrsync/helpers/rsync.py
@@ -55,4 +55,4 @@ def get_rsh_command(private_key: Optional[str] = None, port: Optional[int] = Non
 
     string_args = " ".join(args)
 
-    return ["--rsh", f"ssh {string_args}"]
+    return ["--rsh", f"'ssh {string_args}'"]

--- a/sysrsync/helpers/rsync.py
+++ b/sysrsync/helpers/rsync.py
@@ -55,4 +55,4 @@ def get_rsh_command(private_key: Optional[str] = None, port: Optional[int] = Non
 
     string_args = " ".join(args)
 
-    return ["--rsh", f"'ssh {string_args}'"]
+    return [f"--rsh='ssh {string_args}'"]


### PR DESCRIPTION
fixes #41 